### PR TITLE
handle-ujson-failiure-gracefully

### DIFF
--- a/logging_opentelemetry_format/utils.py
+++ b/logging_opentelemetry_format/utils.py
@@ -141,7 +141,7 @@ class OpentelemetryLogFormatter(logging.Formatter):
             message_string = ujson.dumps(
                 record_dict, indent=self.json_indent)
         except TypeError as e:
-            logger.info("ujson failed to serialize, falling back to default json serializer")
+            logger.debug("ujson failed to serialize, falling back to default json serializer")
             message_string = json.dumps(
                 record_dict, indent=None, default=str)
         except Exception as e:

--- a/logging_opentelemetry_format/utils.py
+++ b/logging_opentelemetry_format/utils.py
@@ -140,6 +140,10 @@ class OpentelemetryLogFormatter(logging.Formatter):
         try:
             message_string = ujson.dumps(
                 record_dict, indent=self.json_indent)
+        except TypeError as e:
+            logger.info("ujson failed to serialize, falling back to default json serializer")
+            message_string = json.dumps(
+                record_dict, indent=None, default=str)
         except Exception as e:
             logger.exception(e)
             message_string = json.dumps(


### PR DESCRIPTION
when ujson fails to serialize python objects like date time the exception gets triggered which is not actually a error as ujson cant deserialize datetime objects or any python specific objects we have to add fallback for that failiure which already is present but that exception is broad and logger.exception gets triggered added an exception to handle type error and added info msg instead raising exception.